### PR TITLE
userのshowやcreateの時にuser_typeも返してあげることにした

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -7,7 +7,8 @@ class Api::V1::UsersController < ApplicationController
 
   def show
     @user = User.find_by(token: request.headers[:Token])
-    render json: @user
+
+    render json: get_user_type(@user)
   end
 
   def create
@@ -23,13 +24,13 @@ class Api::V1::UsersController < ApplicationController
     @user.new_token
     @user.save!
 
-    render json: @user
+    render json: get_user_type(@user)
   end
 
   def update
     @user = User.find(params[:id])
     @user.update(user_params)
-    render json: @user
+    render json: get_user_type(@user)
   end
 
   def destroy
@@ -43,6 +44,12 @@ class Api::V1::UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name)
+  end
+
+  def get_user_type(user)
+    json = JSON.parse(user.to_json)
+    json[:user_type] = user.user_type
+    json
   end
 
 end


### PR DESCRIPTION
背景：多分カテゴリを表示するときにそのユーザーのユーザータイプを見て表示してあげることになると思うんだけど、ユーザがカラムとしてデータを持っているのはuser_type_idだけ。ネイティブの画面上からはgeneration_idとgender_idを指定して、カテゴリをindexする仕様なので返して上げる必要があった
